### PR TITLE
use 0 contrast for custom lcd

### DIFF
--- a/watch-library/hardware/watch/watch_slcd.c
+++ b/watch-library/hardware/watch/watch_slcd.c
@@ -252,7 +252,7 @@ void watch_enable_display(void) {
     slcd_clear();
 
     if (_installed_display == WATCH_LCD_TYPE_CUSTOM) {
-        slcd_set_contrast(4);
+        slcd_set_contrast(0);
     } else {
         slcd_set_contrast(9);
     }


### PR DESCRIPTION
this greatly improves off axis viewing, for an extremely slightly reduction in actual contrast when viewed on axis.