### PR TITLE
Fix simulator light ADC returning wrong values for UI lux buttons

### DIFF
--- a/watch-library/simulator/shell.html
+++ b/watch-library/simulator/shell.html
@@ -1552,15 +1552,15 @@
     </div>
     <h2>Light</h2>
     <div style="display: flex; gap: 6px; align-items: center;">
-      <div class="light-swatch" onclick="setLight(0)" title="Dark (0 lux)"
+      <div class="light-swatch" onclick="setLight(0)" title="Dark"
            style="width:36px;height:36px;background:#000;border:2px solid #555;border-radius:4px;cursor:pointer;"></div>
-      <div class="light-swatch" onclick="setLight(5)" title="Dim (5 lux)"
+      <div class="light-swatch" onclick="setLight(100)" title="Dim"
            style="width:36px;height:36px;background:#444;border:2px solid #555;border-radius:4px;cursor:pointer;"></div>
-      <div class="light-swatch" onclick="setLight(300)" title="Indoor (300 lux)"
+      <div class="light-swatch" onclick="setLight(5000)" title="Indoor"
            style="width:36px;height:36px;background:#aaa;border:2px solid #555;border-radius:4px;cursor:pointer;"></div>
-      <div class="light-swatch" onclick="setLight(10000)" title="Bright (10000 lux)"
+      <div class="light-swatch" onclick="setLight(40000)" title="Bright"
            style="width:36px;height:36px;background:#fff;border:2px solid #555;border-radius:4px;cursor:pointer;"></div>
-      <span id="light-lux-display" style="font-size:0.85em;">0 lux</span>
+      <span id="light-level-display" style="font-size:0.85em;">0</span>
     </div>
   </div>
 
@@ -1620,7 +1620,7 @@
   lon = 0;
   tx = "";
   temp_c = 25.0;
-  light_lux = 0.0;
+  light_level = 0.0;
   function updateLocation(location) {
     lat = Math.round(location.coords.latitude * 100);
     lon = Math.round(location.coords.longitude * 100);
@@ -1714,15 +1714,15 @@
     }
   }
 
-  function setLight(lux) {
-    light_lux = lux;
-    var display = document.getElementById("light-lux-display");
-    if (display) display.textContent = lux + " lux";
+  function setLight(level) {
+    light_level = level;
+    var display = document.getElementById("light-level-display");
+    if (display) display.textContent = level;
     // Highlight the active swatch
     var swatches = document.querySelectorAll(".light-swatch");
     swatches.forEach(function(s) { s.style.outline = "none"; });
-    var luxValues = [0, 5, 300, 10000];
-    var idx = luxValues.indexOf(lux);
+    var levelValues = [0, 100, 5000, 40000];
+    var idx = levelValues.indexOf(level);
     if (idx >= 0 && swatches[idx]) {
       swatches[idx].style.outline = "2px solid #0e57a9";
     }

--- a/watch-library/simulator/watch/watch_adc.c
+++ b/watch-library/simulator/watch/watch_adc.c
@@ -26,15 +26,15 @@
 #include <emscripten.h>
 
 static uint16_t _sim_get_light_adc_value(void) {
-    // Return the simulated lux value directly as the ADC reading.
-    // Watch faces like light_sensor_face display the raw ADC value,
-    // so this keeps the displayed number consistent with the UI controls.
-    double lux = EM_ASM_DOUBLE({
-        return window.light_lux || 0.0;
+    // Return the simulated light level directly as the ADC reading.
+    // UI presets approximate an IR photodiode's response across the
+    // 16-bit ADC range (0 = dark, 65535 = saturated).
+    double level = EM_ASM_DOUBLE({
+        return window.light_level || 0.0;
     });
-    if (lux <= 0) return 0;
-    if (lux >= 65535.0) return 65535;
-    return (uint16_t)lux;
+    if (level <= 0) return 0;
+    if (level >= 65535.0) return 65535;
+    return (uint16_t)level;
 }
 
 void watch_enable_adc(void) {}

--- a/watch-library/simulator/watch/watch_adc.c
+++ b/watch-library/simulator/watch/watch_adc.c
@@ -26,14 +26,15 @@
 #include <emscripten.h>
 
 static uint16_t _sim_get_light_adc_value(void) {
-    // Read the simulated lux value and map it to a 16-bit ADC range.
-    // OPT3001 max range is ~83865 lux; we scale proportionally.
+    // Return the simulated lux value directly as the ADC reading.
+    // Watch faces like light_sensor_face display the raw ADC value,
+    // so this keeps the displayed number consistent with the UI controls.
     double lux = EM_ASM_DOUBLE({
         return window.light_lux || 0.0;
     });
     if (lux <= 0) return 0;
-    if (lux >= 83865.0) return 65535;
-    return (uint16_t)(lux * 65535.0 / 83865.0);
+    if (lux >= 65535.0) return 65535;
+    return (uint16_t)lux;
 }
 
 void watch_enable_adc(void) {}


### PR DESCRIPTION
The simulator was scaling lux values against the OPT3001 max range (83865 lux → 65535 ADC), but the light sensor face displays raw ADC values directly. This caused 10000 lux to show as 7814 and 5 lux to show as 3. Pass through the lux value directly as the ADC reading so the displayed value matches the UI controls.

https://claude.ai/code/session_015iXHr9kvwp2f3VBARevbKF